### PR TITLE
fix: correct typo in variable name

### DIFF
--- a/Source/ArmASR/Private/ArmASR.cpp
+++ b/Source/ArmASR/Private/ArmASR.cpp
@@ -607,7 +607,7 @@ UE::Renderer::Private::ITemporalUpscaler::FOutputs FArmASRTemporalUpscaler::AddP
 			RDG_EVENT_NAME("Reconstruct Previous Depth (PS)"),
 			RpdShader,
 			RpdShaderParameters,
-			OutputViewport.Rect);
+			InputViewport.Rect);
 	}
 
 	// Depth Clip Shader


### PR DESCRIPTION
Replaced outputViewport with inputViewport in 'Reconstruct
Previous Depth (PS)' pass to align with generic library.

Resolves: DEVTECH-644

Signed-off-by: Fred Jin <fred.jin@arm.com>
Change-Id: I57dc200db50153d1fb0e215ece865ad4c0ab507d