### PR TITLE
fix: correct a macro typo

### DIFF
--- a/Shaders/Private/fsr2/ffxm_fsr2_callbacks_hlsl.h
+++ b/Shaders/Private/fsr2/ffxm_fsr2_callbacks_hlsl.h
@@ -925,7 +925,7 @@ FfxFloat32 Exposure()
 
     return exposure;
 }
-#elif defined(FFXM_FSR2_OPTION_SHADER_OPT_PERFORMANCE)
+#elif defined(FFXM_FSR2_OPTION_SHADER_OPT_ULTRA_PERFORMANCE)
 FfxFloat32 Exposure()
 {
     return 1.0;

--- a/Source/ArmASR/Private/ArmASR.cpp
+++ b/Source/ArmASR/Private/ArmASR.cpp
@@ -169,6 +169,7 @@ public:
 		InternalReactive{ nullptr },
 		LumaHistory{ nullptr },
 		DilatedMotionVectors{ nullptr },
+		DilatedDepthMotionVectorsInputLuma{ nullptr },
 		LockStatus{ nullptr },
 		PreExposure { 0.0 }
 	{};


### PR DESCRIPTION
Replaced "FFXM_FSR2_OPTION_SHADER_OPT_PERFORMANCE" with "FFXM_FSR2_OPTION_SHADER_OPT_ULTRA_PERFORMANCE" and 
initialized "DilatedDepthMotionVectorsInputLuma" in construction function


Change-Id: Ie01b27b2d7a1ae9510b19754d644d469ca027230