### PR TITLE
fix several errors to enable arm asr on ios devices

### DIFF
--- a/Shaders/Private/ConvertVelocity.usf
+++ b/Shaders/Private/ConvertVelocity.usf
@@ -43,7 +43,7 @@ float3 ComputeStaticVelocity(float2 ScreenPos, float DeviceZ)
 Texture2D InputDepth;
 Texture2D InputVelocity;
 
-float2 main(float4 SvPosition : SV_POSITION) : SV_Target0
+float2 MainPS(float4 SvPosition : SV_POSITION) : SV_Target0
 {
     uint2 Pos = uint2(SvPosition.xy);
     float2 Velocity = 0;

--- a/Shaders/Private/CreateReactiveMask.usf
+++ b/Shaders/Private/CreateReactiveMask.usf
@@ -61,8 +61,8 @@ uint LumenSpecularCurrentFrame;
 
 struct Outputs
 {
-    float ReactiveMask : SV_TARGET0;
-    float CompositeMask : SV_TARGET1;
+    float ReactiveMask : SV_Target0;
+    float CompositeMask : SV_Target1;
 };
 
 Outputs MainPS(float4 SvPosition : SV_POSITION)

--- a/Shaders/Private/CreateReactiveMask.usf
+++ b/Shaders/Private/CreateReactiveMask.usf
@@ -65,7 +65,7 @@ struct Outputs
     float CompositeMask : SV_TARGET1;
 };
 
-Outputs main(float4 SvPosition : SV_POSITION)
+Outputs MainPS(float4 SvPosition : SV_POSITION)
 {
     uint2 uPixelCoord = uint2(SvPosition.xy);
 

--- a/Shaders/Private/fsr2/ffxm_fsr2_accumulate_pass_fs.hlsl
+++ b/Shaders/Private/fsr2/ffxm_fsr2_accumulate_pass_fs.hlsl
@@ -95,7 +95,7 @@ struct AccumulateOutputsFS
 #endif
 };
 
-AccumulateOutputsFS main(float4 SvPosition : SV_POSITION)
+AccumulateOutputsFS MainPS(float4 SvPosition : SV_POSITION)
 {
     uint2 uPixelCoord = uint2(SvPosition.xy);
     AccumulateOutputs result = Accumulate(uPixelCoord);

--- a/Shaders/Private/fsr2/ffxm_fsr2_accumulate_pass_fs.hlsl
+++ b/Shaders/Private/fsr2/ffxm_fsr2_accumulate_pass_fs.hlsl
@@ -73,24 +73,24 @@ struct VertexOut
 struct AccumulateOutputsFS
 {
 #if FFXM_FSR2_OPTION_SHADER_OPT_ULTRA_PERFORMANCE
-    FfxFloat32x3 fUpscaledColor    : SV_TARGET0;
-    FfxFloat32x2 fLockStatus        : SV_TARGET1;
+    FfxFloat32x3 fUpscaledColor    : SV_Target0;
+    FfxFloat32x2 fLockStatus        : SV_Target1;
 #if FFXM_FSR2_OPTION_APPLY_SHARPENING == 0
-    FfxFloat32x3 fColor             : SV_TARGET2;
+    FfxFloat32x3 fColor             : SV_Target2;
 #endif
 #elif !FFXM_SHADER_QUALITY_BALANCED_OR_PERFORMANCE
-    FfxFloat32x4 fColorAndWeight    : SV_TARGET0;
-    FfxFloat32x2 fLockStatus        : SV_TARGET1;
-    FfxFloat32x4 fLumaHistory       : SV_TARGET2;
+    FfxFloat32x4 fColorAndWeight    : SV_Target0;
+    FfxFloat32x2 fLockStatus        : SV_Target1;
+    FfxFloat32x4 fLumaHistory       : SV_Target2;
 #if FFXM_FSR2_OPTION_APPLY_SHARPENING == 0
-    FfxFloat32x3 fColor             : SV_TARGET3;
+    FfxFloat32x3 fColor             : SV_Target3;
 #endif
 #else // FFXM_SHADER_QUALITY_BALANCED_OR_PERFORMANCE
-    FfxFloat32x3 fUpscaledColor     : SV_TARGET0;
-    FfxFloat32 fTemporalReactive    : SV_TARGET1;
-    FfxFloat32x2 fLockStatus        : SV_TARGET2;
+    FfxFloat32x3 fUpscaledColor     : SV_Target0;
+    FfxFloat32 fTemporalReactive    : SV_Target1;
+    FfxFloat32x2 fLockStatus        : SV_Target2;
 #if FFXM_FSR2_OPTION_APPLY_SHARPENING == 0
-    FfxFloat32x3 fColor             : SV_TARGET3;
+    FfxFloat32x3 fColor             : SV_Target3;
 #endif
 #endif
 };

--- a/Shaders/Private/fsr2/ffxm_fsr2_autogen_reactive_pass_fs.hlsl
+++ b/Shaders/Private/fsr2/ffxm_fsr2_autogen_reactive_pass_fs.hlsl
@@ -31,7 +31,7 @@
 
 struct GenReactiveMaskOutputs
 {
-    FfxFloat32 fReactiveMask : SV_TARGET0;
+    FfxFloat32 fReactiveMask : SV_Target0;
 };
 
 struct VertexOut

--- a/Shaders/Private/fsr2/ffxm_fsr2_compute_luminance_pyramid_pass.hlsl
+++ b/Shaders/Private/fsr2/ffxm_fsr2_compute_luminance_pyramid_pass.hlsl
@@ -50,7 +50,7 @@
 FFXM_PREFER_WAVE64
 FFXM_FSR2_NUM_THREADS
 FFXM_FSR2_EMBED_CB2_ROOTSIG_CONTENT
-void main(uint3 WorkGroupId : SV_GroupID, uint LocalThreadIndex : SV_GroupIndex)
+void MainCS(uint3 WorkGroupId : SV_GroupID, uint LocalThreadIndex : SV_GroupIndex)
 {
     ComputeAutoExposure(WorkGroupId, LocalThreadIndex);
 }

--- a/Shaders/Private/fsr2/ffxm_fsr2_depth_clip_pass_fs.hlsl
+++ b/Shaders/Private/fsr2/ffxm_fsr2_depth_clip_pass_fs.hlsl
@@ -53,9 +53,9 @@ struct VertexOut
 
 struct DepthClipOutputsFS
 {
-    FfxFloat32x2 fDilatedReactiveMasks    : SV_TARGET0;
+    FfxFloat32x2 fDilatedReactiveMasks    : SV_Target0;
 #if !FFXM_FSR2_OPTION_SHADER_OPT_ULTRA_PERFORMANCE
-    FfxFloat32x4 fTonemapped              : SV_TARGET1;
+    FfxFloat32x4 fTonemapped              : SV_Target1;
 #endif
 };
 

--- a/Shaders/Private/fsr2/ffxm_fsr2_depth_clip_pass_fs.hlsl
+++ b/Shaders/Private/fsr2/ffxm_fsr2_depth_clip_pass_fs.hlsl
@@ -59,7 +59,7 @@ struct DepthClipOutputsFS
 #endif
 };
 
-DepthClipOutputsFS main(float4 SvPosition : SV_POSITION)
+DepthClipOutputsFS MainPS(float4 SvPosition : SV_POSITION)
 {
     uint2 uPixelCoord = uint2(SvPosition.xy);
     DepthClipOutputs result = DepthClip(uPixelCoord);

--- a/Shaders/Private/fsr2/ffxm_fsr2_lock_pass.hlsl
+++ b/Shaders/Private/fsr2/ffxm_fsr2_lock_pass.hlsl
@@ -51,7 +51,7 @@
 FFXM_PREFER_WAVE64
 FFXM_FSR2_NUM_THREADS
 FFXM_FSR2_EMBED_ROOTSIG_CONTENT
-void main(uint2 uGroupId : SV_GroupID, uint2 uGroupThreadId : SV_GroupThreadID)
+void MainCS(uint2 uGroupId : SV_GroupID, uint2 uGroupThreadId : SV_GroupThreadID)
 {
     uint2 uDispatchThreadId = uGroupId * uint2(FFXM_FSR2_THREAD_GROUP_WIDTH, FFXM_FSR2_THREAD_GROUP_HEIGHT) + uGroupThreadId;
 

--- a/Shaders/Private/fsr2/ffxm_fsr2_rcas_pass_fs.hlsl
+++ b/Shaders/Private/fsr2/ffxm_fsr2_rcas_pass_fs.hlsl
@@ -40,7 +40,7 @@ struct RCASOutputsFS
     FfxFloat32x3 fUpscaledColor    : SV_TARGET0;
 };
 
-RCASOutputsFS main(float4 SvPosition : SV_POSITION)
+RCASOutputsFS MainPS(float4 SvPosition : SV_POSITION)
 {
     uint2 uPixelCoord = uint2(SvPosition.xy);
     RCASOutputs result = RCAS(uPixelCoord);

--- a/Shaders/Private/fsr2/ffxm_fsr2_rcas_pass_fs.hlsl
+++ b/Shaders/Private/fsr2/ffxm_fsr2_rcas_pass_fs.hlsl
@@ -37,7 +37,7 @@ struct VertexOut
 
 struct RCASOutputsFS
 {
-    FfxFloat32x3 fUpscaledColor    : SV_TARGET0;
+    FfxFloat32x3 fUpscaledColor    : SV_Target0;
 };
 
 RCASOutputsFS MainPS(float4 SvPosition : SV_POSITION)

--- a/Shaders/Private/fsr2/ffxm_fsr2_reconstruct_previous_depth_pass_fs.hlsl
+++ b/Shaders/Private/fsr2/ffxm_fsr2_reconstruct_previous_depth_pass_fs.hlsl
@@ -55,7 +55,7 @@ struct ReconstructPrevDepthOutputsFS
 };
 
 
-ReconstructPrevDepthOutputsFS main(float4 SvPosition : SV_POSITION)
+ReconstructPrevDepthOutputsFS MainPS(float4 SvPosition : SV_POSITION)
 {
     uint2 uPixelCoord = uint2(SvPosition.xy);
     ReconstructPrevDepthOutputs result = ReconstructAndDilate(uPixelCoord);

--- a/Shaders/Private/fsr2/ffxm_fsr2_reconstruct_previous_depth_pass_fs.hlsl
+++ b/Shaders/Private/fsr2/ffxm_fsr2_reconstruct_previous_depth_pass_fs.hlsl
@@ -46,11 +46,11 @@ struct VertexOut
 struct ReconstructPrevDepthOutputsFS
 {
 #if FFXM_FSR2_OPTION_SHADER_OPT_ULTRA_PERFORMANCE
-    FfxFloat32x4 fDepthMotionVectorLuma: SV_TARGET0;
+    FfxFloat32x4 fDepthMotionVectorLuma: SV_Target0;
 #else
-    FfxFloat32 fDepth           : SV_TARGET0;
-    FfxFloat32x2 fMotionVector  : SV_TARGET1;
-    FfxFloat32 fLuma            : SV_TARGET2;
+    FfxFloat32 fDepth           : SV_Target0;
+    FfxFloat32x2 fMotionVector  : SV_Target1;
+    FfxFloat32 fLuma            : SV_Target2;
 #endif
 };
 

--- a/Source/ArmASR/ArmASR.Build.cs
+++ b/Source/ArmASR/ArmASR.Build.cs
@@ -46,8 +46,7 @@ public class ArmASR : ModuleRules
 				"Renderer",
 				"RenderCore",
 				"Projects",
-				"RHI",
-				"VulkanRHI"
+				"RHI"
 				// ... add private dependencies that you statically link with here ...
 			}
 		);
@@ -63,6 +62,7 @@ public class ArmASR : ModuleRules
 			|| Target.IsInPlatformGroup(UnrealPlatformGroup.Android))
 		{
 			AddEngineThirdPartyPrivateStaticDependencies(Target, "Vulkan");
+			AddEngineThirdPartyPrivateStaticDependencies(Target, "VulkanRHI");
 		}
 	}
 }

--- a/Source/ArmASR/Private/ArmASR.cpp
+++ b/Source/ArmASR/Private/ArmASR.cpp
@@ -152,16 +152,16 @@ TAutoConsoleVariable<int32> CVarArmASRReactiveMaskReactiveShadingModelID(
 	ECVF_RenderThreadSafe
 );
 
-IMPLEMENT_GLOBAL_SHADER(FArmASRAccumulatePS, "/Plugin/ArmASR/Private/AccumulatePass.usf", "main", SF_Pixel);
+IMPLEMENT_GLOBAL_SHADER(FArmASRAccumulatePS, "/Plugin/ArmASR/Private/AccumulatePass.usf", "MainPS", SF_Pixel);
 IMPLEMENT_GLOBAL_SHADER(FArmASRComputeLuminancePyramidCS, "/Plugin/ArmASR/Private/ComputeLuminancePyramidPass.usf",
-						"main", SF_Compute);
-IMPLEMENT_GLOBAL_SHADER(FArmASRConvertVelocity, "/Plugin/ArmASR/Private/ConvertVelocity.usf", "main", SF_Pixel);
+						"MainCS", SF_Compute);
+IMPLEMENT_GLOBAL_SHADER(FArmASRConvertVelocity, "/Plugin/ArmASR/Private/ConvertVelocity.usf", "MainPS", SF_Pixel);
 IMPLEMENT_GLOBAL_SHADER(FArmASRCopyExposureCS, "/Plugin/ArmASR/Private/CopyExposure.usf", "MainCS", SF_Compute);
-IMPLEMENT_GLOBAL_SHADER(FArmASRCreateReactiveMaskPS, "/Plugin/ArmASR/Private/CreateReactiveMask.usf", "main", SF_Pixel);
-IMPLEMENT_GLOBAL_SHADER(FArmASRDepthClipPS, "/Plugin/ArmASR/Private/DepthClipPass.usf", "main", SF_Pixel);
-IMPLEMENT_GLOBAL_SHADER(FArmASRLockCS, "/Plugin/ArmASR/Private/LockPass.usf", "main", SF_Compute);
-IMPLEMENT_GLOBAL_SHADER(FArmASRRCASPS, "/Plugin/ArmASR/Private/RCASPass.usf", "main", SF_Pixel);
-IMPLEMENT_GLOBAL_SHADER(FArmASRReconstructPrevDepthPS, "/Plugin/ArmASR/Private/ReconstructPrevDepthPass.usf", "main",
+IMPLEMENT_GLOBAL_SHADER(FArmASRCreateReactiveMaskPS, "/Plugin/ArmASR/Private/CreateReactiveMask.usf", "MainPS", SF_Pixel);
+IMPLEMENT_GLOBAL_SHADER(FArmASRDepthClipPS, "/Plugin/ArmASR/Private/DepthClipPass.usf", "MainPS", SF_Pixel);
+IMPLEMENT_GLOBAL_SHADER(FArmASRLockCS, "/Plugin/ArmASR/Private/LockPass.usf", "MainCS", SF_Compute);
+IMPLEMENT_GLOBAL_SHADER(FArmASRRCASPS, "/Plugin/ArmASR/Private/RCASPass.usf", "MainPS", SF_Pixel);
+IMPLEMENT_GLOBAL_SHADER(FArmASRReconstructPrevDepthPS, "/Plugin/ArmASR/Private/ReconstructPrevDepthPass.usf", "MainPS",
 						SF_Pixel);
 
 // History written by frame N and read by frame N + 1.

--- a/Source/ArmASR/Private/ArmASR.cpp
+++ b/Source/ArmASR/Private/ArmASR.cpp
@@ -10,7 +10,11 @@
 #include "ArmASRPassthroughDenoiser.h"
 #include "ArmASRSettings.h"
 
+#if PLATFORM_IOS || PLATFORM_MAC
+#define ARM_ASR_ENABLE_VK 0
+#else
 #define ARM_ASR_ENABLE_VK 1
+#endif
 
 #if ARM_ASR_ENABLE_VK
 #include "IVulkanDynamicRHI.h"


### PR DESCRIPTION
### fix asr compilation error on macos & ios

remove vulkan dependency on mscos & ios builds.

### fix ios metal shader compilation error

```log
LogShaders: Error: Archiving failed: metallib failed with code 1:  LLVM ERROR: multiple symbols ('main0')!
```

avoid using "main" as shader entry function name.

### fix metal pso compilation error

```log
LogMetal: Error: Pixel shader has no outputs which is not permitted. No Discards, In-Out Mask: 0 Number UAVs: 0 Source Code: Hash: *, Name: Main_*_*
```

this is because unreal engine's shader cross compiler does not recognize fully uppercase `SV_TARGET`.
use `SV_Target` instead.